### PR TITLE
dhc/caas: increase /var/log to 2GB

### DIFF
--- a/images/capi/hack/image-build-vmdk-optimize-qcow2.sh
+++ b/images/capi/hack/image-build-vmdk-optimize-qcow2.sh
@@ -3,7 +3,7 @@
 BUILD_DIR=$1
 
 echo "Converting qcow2 to streamOptimized vmdk"
-qemu-img convert -f qcow2 -O vmdk -o subformat=streamOptimized ${BUILD_DIR}/qemu-kube-v1.17.3 ${BUILD_DIR}/qemu-kube-v1.17.3.vmdk
+qemu-img convert -f qcow2 -O vmdk -o subformat=streamOptimized "${BUILD_DIR}"/qemu-kube-v1.17.11 "${BUILD_DIR}"/qemu-kube-v1.17.11.vmdk
 
 echo "Compressing qcow2"
-qemu-img convert -f qcow2 -O qcow2 -c ${BUILD_DIR}/qemu-kube-v1.17.3 ${BUILD_DIR}/qemu-kube-v1.17.3.qcow2
+qemu-img convert -f qcow2 -O qcow2 -c "${BUILD_DIR}"/qemu-kube-v1.17.11 "${BUILD_DIR}"/qemu-kube-v1.17.11.qcow2

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -58,7 +58,7 @@ d-i partman-auto/expert_recipe string                         \
                       use_filesystem{ } filesystem{ xfs }     \
                       mountpoint{ / }                         \
                       .                                       \
-              900 10000 1000 xfs                              \
+              1900 10000 2000 xfs                             \
                       $primary{ }                             \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ xfs }     \


### PR DESCRIPTION
The partition for /var/log is mostly used to 98%. As there is enough space available, the partition is increased to 2GB.
The build directory is adapted to the upstream used k8s v1.17.11.