### PR TITLE
images/capi configure chrony.conf makestep analog to azure

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -68,11 +68,11 @@
     enabled: false
   when: ansible_os_family != "Debian"
 
-- name: Ensure auditd is running and comes on at reboot
+- name: Ensure auditd is stopped and disabled
   service:
     name: auditd
-    state: started
-    enabled: yes
+    state: stopped
+    enabled: false
 
 - name: configure auditd rules for containerd
   copy:

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -92,3 +92,15 @@
   patch:
     src: files/debian/DataSourceOpenStack.patch
     dest: /usr/lib/python3/dist-packages/cloudinit/sources/DataSourceOpenStack.py
+
+- name: Ensure makestep parameter set
+  lineinfile:
+    path: /etc/chrony/chrony.conf
+    regexp: '^makestep'
+    line: makestep 1.0 -1
+
+- name: Ensure makestep parameter set in template for cloud-init
+  lineinfile:
+    path: /etc/cloud/templates/chrony.conf.ubuntu.tmpl
+    regexp: '^makestep'
+    line: makestep 1.0 -1


### PR DESCRIPTION
`makestep 1.0 -1`

* the `1.0` enforces timesyncs instead of small shifts when the the difference is > 1 second.
* the `-1` allows chrony to always do this timesync when the shift is detected.