### PR TITLE
hwe kernel 5.8 and containerd 1.4.3

### DIFF
--- a/images/capi/ansible/roles/dhc/tasks/debian.yml
+++ b/images/capi/ansible/roles/dhc/tasks/debian.yml
@@ -1,4 +1,14 @@
 ---
+- name: Install HWE Kernel 5.8
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+    install_recommends: yes
+  vars:
+    packages:
+      - linux-image-virtual-hwe-20.04
+
 - name: Install custom DHC tools
   apt:
     name: "{{ packages }}"

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.4.1",
-    "containerd_sha256": "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
+    "containerd_version": "1.4.3",
+    "containerd_sha256": "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null,
     "containerd_cri_socket": "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
Install linux-image-virtual-hwe-20.04 to use the latest/stable 5.8 Kernel. This is necessary because SLAB on 5.8+ can be reclaimed by dropping the cache: `echo 2 > /proc/sys/vm/drop_caches`.
Also update `containerd` to 1.4.3