### PR TITLE
caas/containerd: version bump to 1.5.4

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.5.3",
-    "containerd_sha256": "32a9bf1b7ab2adbd9d2a16b17bf1aa6e61592938655adfb5114c40d527aa9be7",
+    "containerd_version": "1.5.4",
+    "containerd_sha256": "591e4e087ea2f5007e6c64deb382df58d419b7b6922eab45a1923d843d57615f",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null,
     "containerd_cri_socket": "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
containerd will solve  CVE-2021-32760