### PR TITLE
images/ansible/cloud-init use sed instead of python to add the timestamp

### DIFF
--- a/images/capi/ansible/roles/dhc/tasks/debian.yml
+++ b/images/capi/ansible/roles/dhc/tasks/debian.yml
@@ -46,6 +46,8 @@
     - vim
     # nfs-common is required to make the mount of nfs-shares possible
     - nfs-common
+    # moreutils is required for ts to add timestamps to the cloud-init log
+    - moreutils
 
 - name: disable apparmor
   systemd:

--- a/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/05_logging.cfg
+++ b/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/05_logging.cfg
@@ -64,4 +64,4 @@ log_cfgs:
 # this tells cloud-init to redirect its stdout and stderr to
 # 'tee -a /var/log/cloud-init-output.log' so the user can see output
 # there without needing to look on the console.
-output: {all: '| python3 -c ''import sys,time;sys.stdout.write("".join(( " ".join((time.strftime("[%Y-%m-%d %H:%M:%S]", time.localtime()), line)) for line in sys.stdin )))'' | tee -a /var/log/cloud-init-output.log'}
+output: {all: '| ts ''[%Y-%m-%d %H:%M:%S]'' | tee -a /var/log/cloud-init-output.log'}


### PR DESCRIPTION
The python pipe did result in waiting for the end of the script and then
writing to the log file. Using sed writes immediately to the log file.