### PR TITLE
images/capi bump linux kernel to mainline 5.15

### DIFF
--- a/images/capi/ansible/roles/dhc/tasks/debian.yml
+++ b/images/capi/ansible/roles/dhc/tasks/debian.yml
@@ -14,7 +14,7 @@
       install_recommends: yes
     vars:
       packages:
-      - linux-generic-5.14
+      - linux-generic-5.15
 
 - name: Install custom DHC tools
   apt:

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.5.7",
-    "containerd_sha256": "7fce75bab43a39d6f9efb3c370de2da49723f0e1dbaa9732d68fa7f620d720c8",
+    "containerd_version": "1.5.9",
+    "containerd_sha256": "f64c8e3b736b370c963b08c33ac70f030fc311bc48fcfd00461465af2fff3488",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null,
     "containerd_cri_socket": "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
5.14 does not exist anymore on the PPA repository