### PR TITLE
Bump containerd to v1.6.0

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.5.9",
-    "containerd_sha256": "f64c8e3b736b370c963b08c33ac70f030fc311bc48fcfd00461465af2fff3488",
+    "containerd_version": "1.6.0",
+    "containerd_sha256": "f7187d0c6f38c33a4bf87b534b4434001fba6eba01ab7877059669da143f67f0",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null,
     "containerd_cri_socket": "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
This PR introduces the option `enable_unprivileged_ports` which would be useful for many customers.